### PR TITLE
A couple tweaks to new Expenses page

### DIFF
--- a/src/AD419/ClientApp/src/components/expenses/ExpenseTable.tsx
+++ b/src/AD419/ClientApp/src/components/expenses/ExpenseTable.tsx
@@ -7,6 +7,7 @@ import { groupBy } from '../../utilities';
 interface Props {
   expenses: UngroupedExpense[];
   loading: boolean;
+  emptyMessage: string;
 }
 
 export default function ExpenseTable(props: Props): JSX.Element {
@@ -95,9 +96,7 @@ export default function ExpenseTable(props: Props): JSX.Element {
       </table>
       {data.length === 0 && (
         <div>
-          <p className='text-center mt-2'>
-            No expenses found for given parameters.
-          </p>
+          <p className='text-center mt-2'>{props.emptyMessage}</p>
         </div>
       )}
     </>

--- a/src/AD419/Controllers/ExpenseController.cs
+++ b/src/AD419/Controllers/ExpenseController.cs
@@ -39,7 +39,7 @@ namespace AD419.Controllers
         [HttpGet("Ungrouped")]
         public async Task<IActionResult> Ungrouped(string org, string sfn)
         {
-            if (!await _permissionService.CanAccessDepartment(User.Identity.Name, org))
+            if (!await _permissionService.IsAdmin(User.Identity.Name))
             {
                 return Forbid();
             }


### PR DESCRIPTION
- Allow only admins to access this page. (Displaying an empty table with a "not authorized" message, since actually hiding the page would require more significant changes to the app.)
- Allow display of expenses from all departments at once.
- Sort expenses by sfn, org, project.