### PR TITLE
Add None grouping option back in

### DIFF
--- a/src/AD419/ClientApp/src/components/associations/ExpenseTable.tsx
+++ b/src/AD419/ClientApp/src/components/associations/ExpenseTable.tsx
@@ -74,6 +74,8 @@ export default function ExpenseTable(props: Props): JSX.Element {
       ? 'Project'
       : grouping === 'Activity'
       ? 'Activity'
+      : grouping === 'None'
+      ? 'ExpenseId'
       : 'Code';
 
   const descriptionHeader =

--- a/src/AD419/ClientApp/src/components/associations/Groupings.tsx
+++ b/src/AD419/ClientApp/src/components/associations/Groupings.tsx
@@ -43,4 +43,8 @@ const groupOptions: Option[] = [
     name: 'Activity',
     value: 'Activity',
   },
+  {
+    name: 'No Grouping',
+    value: 'None',
+  },
 ];


### PR DESCRIPTION
Sprocs have already been updated to handle the `None` grouping option.