### PR TITLE
Add new Fund/Project grouping along with new Code2 column

### DIFF
--- a/src/AD419/ClientApp/src/components/associations/ExpenseTable.tsx
+++ b/src/AD419/ClientApp/src/components/associations/ExpenseTable.tsx
@@ -46,6 +46,10 @@ export default function ExpenseTable(props: Props): JSX.Element {
     return !(grouping === 'PI' || grouping === 'Employee');
   }, [grouping]);
 
+  const showCode2 = useMemo(() => {
+    return grouping === 'Fund/Project';
+  }, [grouping]);
+
   const data = useMemo(() => {
     if (filter) {
       const lowerFilter = filter.toLowerCase();
@@ -70,13 +74,15 @@ export default function ExpenseTable(props: Props): JSX.Element {
   const codeHeader =
     grouping === 'FinancialDepartment'
       ? 'Fin Dept'
-      : grouping === 'Project'
+      : grouping === 'Project' || grouping === 'Fund/Project'
       ? 'Project'
       : grouping === 'Activity'
       ? 'Activity'
       : grouping === 'None'
       ? 'ExpenseId'
       : 'Code';
+
+  const code2Header = grouping === 'Fund/Project' ? 'Fund' : 'Code2';
 
   const descriptionHeader =
     grouping === 'FinancialDepartment'
@@ -99,6 +105,7 @@ export default function ExpenseTable(props: Props): JSX.Element {
           <tr>
             <th>Num</th>
             <th>Entity</th>
+            {showCode2 && <th>{code2Header}</th>}
             {showCode && <th>{codeHeader}</th>}
             <th>{descriptionHeader}</th>
             <th>Spent</th>
@@ -116,7 +123,12 @@ export default function ExpenseTable(props: Props): JSX.Element {
             >
               <td>{expense.num}</td>
               <td>{expense.entity}</td>
-              {showCode && <td>{expense.code || '----'}</td>}
+              {showCode2 && <td>{expense.code2 || '----'}</td>}
+              {showCode && (
+                <td style={{ whiteSpace: 'nowrap' }}>
+                  {expense.code || '----'}
+                </td>
+              )}
               <td>{expense.description || '----'}</td>
               <td>
                 <NumberDisplay

--- a/src/AD419/ClientApp/src/components/associations/Groupings.tsx
+++ b/src/AD419/ClientApp/src/components/associations/Groupings.tsx
@@ -36,6 +36,10 @@ const groupOptions: Option[] = [
     value: 'Project',
   },
   {
+    name: 'Fund and Project',
+    value: 'Fund/Project',
+  },
+  {
     name: 'Employee',
     value: 'Employee',
   },

--- a/src/AD419/ClientApp/src/models/index.ts
+++ b/src/AD419/ClientApp/src/models/index.ts
@@ -25,6 +25,7 @@ export interface Expense {
   entity: number;
   code: string;
   description: string;
+  code2: string;
   spent: number;
   fte: number;
   num: number;

--- a/src/AD419/Controllers/AssociationController.cs
+++ b/src/AD419/Controllers/AssociationController.cs
@@ -57,7 +57,14 @@ namespace AD419.Controllers
                 {
                     // TODO: NOTE: need to use the new version of this SPROC
                     var expenseAssociations = await conn.QueryAsync<AssociationModel>("usp_getAssociationsByGroupingAE",
-                        new { OrgR = model.ExpenseGrouping.Org, Grouping = model.ExpenseGrouping.Grouping, Entity = expense.Entity, Criterion = expense.Code, isAssociated = expense.IsAssociated },
+                        new { 
+                            OrgR = model.ExpenseGrouping.Org, 
+                            Grouping = model.ExpenseGrouping.Grouping, 
+                            Entity = expense.Entity, 
+                            Criterion = expense.Code, 
+                            Criterion2 = expense.Code2,
+                            isAssociated = expense.IsAssociated 
+                        },
                         commandType: CommandType.StoredProcedure);
 
                     associations.AddRange(expenseAssociations);
@@ -103,6 +110,7 @@ namespace AD419.Controllers
                                     Grouping = model.ExpenseGrouping.Grouping,
                                     Entity = expense.Entity,
                                     Criterion = expense.Code,
+                                    Criterion2 = expense.Code2,
                                     isAssociated = expense.IsAssociated
                                 },
                                 commandType: CommandType.StoredProcedure, transaction: txn);
@@ -212,7 +220,14 @@ namespace AD419.Controllers
                         foreach (var expense in model.Expenses)
                         {
                             var expenseIdentifiers = await conn.QueryAsync<ExpenseDetail>("usp_getExpensesByRecordGroupingAE",
-                                new { OrgR = model.ExpenseGrouping.Org, Grouping = model.ExpenseGrouping.Grouping, Entity = expense.Entity, Criterion = expense.Code, isAssociated = expense.IsAssociated },
+                                new { 
+                                    OrgR = model.ExpenseGrouping.Org, 
+                                    Grouping = model.ExpenseGrouping.Grouping, 
+                                    Entity = expense.Entity, 
+                                    Criterion = expense.Code, 
+                                    Criterion2 = expense.Code2, 
+                                    isAssociated = expense.IsAssociated 
+                                },
                                 commandType: CommandType.StoredProcedure, transaction: txn);
 
                             foreach (var expenseIdentifier in expenseIdentifiers)

--- a/src/AD419/Controllers/ExpenseController.cs
+++ b/src/AD419/Controllers/ExpenseController.cs
@@ -66,6 +66,7 @@ namespace AD419.Controllers
         public int Entity { get; set; }
         public string Code { get; set; }
         public string Description { get; set; }
+        public string Code2 { get; set; }
         public decimal Spent { get; set; }
         public decimal FTE { get; set; }
         public int Num { get; set; }


### PR DESCRIPTION
Also made some necessary changes to related sprocs...

- **usp_getExpenseRecordGroupingAE**: Add Fund/Project grouping along with new Code2 column in results
- **usp_getExpensesByRecordGroupingAE**: Add Fund/Project grouping along with new @Criterion2 param for filtering on Fund
- **usp_getAssociationsByGroupingAE**: Add Fund/Project grouping along with new @Criterion2 param for filtering on Fund