### PR TITLE
Fix expense table styles

### DIFF
--- a/src/AD419/ClientApp/src/components/associations/ExpenseTable.tsx
+++ b/src/AD419/ClientApp/src/components/associations/ExpenseTable.tsx
@@ -100,7 +100,7 @@ export default function ExpenseTable(props: Props): JSX.Element {
       <div className='card-body card-bg'>
         <TableFilter filter={filter} setFilter={setFilter}></TableFilter>
       </div>
-      <table className='table expense-table'>
+      <table className='table'>
         <thead>
           <tr>
             <th>Num</th>
@@ -108,8 +108,8 @@ export default function ExpenseTable(props: Props): JSX.Element {
             {showCode2 && <th>{code2Header}</th>}
             {showCode && <th>{codeHeader}</th>}
             <th>{descriptionHeader}</th>
-            <th>Spent</th>
-            <th>FTE</th>
+            <th className='expense-numeric'>Spent</th>
+            <th className='expense-numeric'>FTE</th>
             <th>{/* Select */}</th>
           </tr>
         </thead>
@@ -129,20 +129,18 @@ export default function ExpenseTable(props: Props): JSX.Element {
               <td>{expense.num}</td>
               <td>{expense.entity}</td>
               {showCode2 && <td>{expense.code2 || '----'}</td>}
-              {showCode && (
-                <td style={{ whiteSpace: 'nowrap' }}>
-                  {expense.code || '----'}
-                </td>
-              )}
-              <td>{expense.description || '----'}</td>
-              <td>
+              {showCode && <td>{expense.code || '----'}</td>}
+              <td className='expense-description'>
+                {expense.description || '----'}
+              </td>
+              <td className='expense-numeric'>
                 <NumberDisplay
                   value={expense.spent}
                   precision={2}
                   type='currency'
                 ></NumberDisplay>
               </td>
-              <td>
+              <td className='expense-numeric'>
                 <NumberDisplay
                   value={expense.fte}
                   precision={4}

--- a/src/AD419/ClientApp/src/components/associations/ExpenseTable.tsx
+++ b/src/AD419/ClientApp/src/components/associations/ExpenseTable.tsx
@@ -116,7 +116,12 @@ export default function ExpenseTable(props: Props): JSX.Element {
         <tbody>
           {data.map((expense) => (
             <tr
-              key={expense.entity + expense.code + expense.isAssociated}
+              key={
+                expense.entity +
+                expense.code +
+                expense.code2 +
+                expense.isAssociated
+              }
               className={`expense-${
                 expense.isAssociated ? 'associated' : 'unassociated'
               }`}

--- a/src/AD419/ClientApp/src/sass/_regions.scss
+++ b/src/AD419/ClientApp/src/sass/_regions.scss
@@ -72,30 +72,14 @@ table.totals-table {
   }
 }
 // Expense table
-table.expense-table {
-  tr {
-    th {
-      &:nth-child(5) {
-        text-align: right;
-      }
-      &:nth-child(6) {
-        text-align: right;
-      }
-    }
-    td {
-      &:nth-child(5) {
-        text-align: right;
-      }
-      &:nth-child(6) {
-        text-align: right;
-      }
-    }
-  }
-  td {
-    &:nth-child(4) {
-      word-break: break-all;
-    }
-  }
+th.expense-numeric {
+  text-align: right;
+}
+td.expense-numeric {
+  text-align: right;
+}
+td.expense-description {
+  word-break: break-all;
 }
 
 // Active row


### PR DESCRIPTION
The nth-child approach of css class `table.expense-table` wasn't workable for a table in which number of columns changes.

Also fixed a bug in related sproc `usp_getExpensesByRecordGroupingAE` that caused `Associate` operations to fail.