### PR TITLE
Include code2 in expense comparisons

### DIFF
--- a/src/AD419/ClientApp/src/components/associations/ExpenseTable.tsx
+++ b/src/AD419/ClientApp/src/components/associations/ExpenseTable.tsx
@@ -18,6 +18,7 @@ export default function ExpenseTable(props: Props): JSX.Element {
     return (
       expA.entity === expB.entity &&
       expA.code === expB.code &&
+      expA.code2 === expB.code2 &&
       expA.isAssociated === expB.isAssociated
     );
   };


### PR DESCRIPTION
Fixes bug in which all expenses in a `Fund/Project` group are checked when checking any one of them.